### PR TITLE
Get language specific workaround

### DIFF
--- a/cypress/integration/contracts/flatrate_conditions_material_tracking_spec.js
+++ b/cypress/integration/contracts/flatrate_conditions_material_tracking_spec.js
@@ -31,7 +31,6 @@ describe('Create material tracking contract conditions', function() {
 
   let countryName;
   before(function() {
-    cy.wait(1000);
     cy.fixture('misc/misc_dictionary.json').then(dictionary => {
       countryName = getLanguageSpecific(dictionary, 'c_country_CH');
     });

--- a/cypress/integration/inventory/create_disposal_from_handling_unit_editor.js
+++ b/cypress/integration/inventory/create_disposal_from_handling_unit_editor.js
@@ -36,8 +36,6 @@ let huValue;
 
 describe('Create a single HU', function() {
   it('Create Product', function() {
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000); // see comment/doc of getLanguageSpecific
     cy.fixture('product/simple_product.json').then(productJson => {
       Object.assign(new Product(), productJson)
         .setName(productName)

--- a/cypress/integration/inventory/inventory_aggregatedHUs_spec.js
+++ b/cypress/integration/inventory/inventory_aggregatedHUs_spec.js
@@ -10,7 +10,6 @@ describe('Aggregated-HUs inventory test', function() {
   const productValue = `${date}`;
 
   before(function() {
-    cy.wait(1000); // see comment/doc of getLanguageSpecific
     cy.fixture('product/simple_product.json').then(productJson => {
       Object.assign(new Product(), productJson)
         .setName(productName)

--- a/cypress/integration/inventory/inventory_singleHU_spec.js
+++ b/cypress/integration/inventory/inventory_singleHU_spec.js
@@ -11,8 +11,6 @@ const locatorId = 'Hauptlager_StdWarehouse_Hauptlager_0_0_0';
 
 describe('Create a single HU', function() {
   it('Create Product', function() {
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000); // see comment/doc of getLanguageSpecific
     cy.fixture('product/simple_product.json').then(productJson => {
       Object.assign(new Product(), productJson)
         .setName(productName)

--- a/cypress/integration/masterdata/discountschema_with_breaks_spec.js
+++ b/cypress/integration/masterdata/discountschema_with_breaks_spec.js
@@ -3,9 +3,10 @@ import { humanReadableNow } from '../../support/utils/utils';
 
 describe('New discount schema Test', function() {
   const date = humanReadableNow();
-  const discountschemaName = `discountschema_with_breaks-${date}`;
-  const productCategoryName = `discountschema_with_breaks-${date}`;
-  const productName = `discountschema_with_breaks-${date}`;
+  const discountschemaName = `dscschema_with_breaks-${date}`;
+  const productCategoryName = `dscschema_with_breaks-${date}`;
+  const productName = `dscschema_with_breaks-${date}`;
+
   it('Create a product to test with', function() {
     cy.fixture('product/simple_productCategory.json').then(productCategoryJson => {
       Object.assign(new ProductCategory(), productCategoryJson)

--- a/cypress/integration/masterdata/warehouse_spec.js
+++ b/cypress/integration/masterdata/warehouse_spec.js
@@ -1,13 +1,10 @@
 import { Warehouse } from '../../support/utils/warehouse';
+import { humanReadableNow } from '../../support/utils/utils';
 
-describe('Create test: warehouse, https://github.com/metasfresh/metasfresh-e2e/issues/46', function() {
-  const date = new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString();
+describe('Create test: warehouse', function() {
+  const date = humanReadableNow();
   const warehouseName = `TestWarehouseName ${date}`;
   const warehouseValue = `TestWarehouseValue ${date}`;
-
-  before(function() {
-    cy.wait(5000);
-  });
 
   it('Create a new warehouse', function() {
     cy.fixture('misc/warehouse.json').then(warehouseJson => {

--- a/cypress/integration/price/add_a_product_to_a_pricelist_schema_and_create_a_new_PLV.js
+++ b/cypress/integration/price/add_a_product_to_a_pricelist_schema_and_create_a_new_PLV.js
@@ -79,10 +79,6 @@ it('Read fixture and prepare the names', function() {
 });
 
 describe('Create Price and Products', function() {
-  it('reaaaaaalyyyyyyyyy', function() {
-    cy.wait(5000);
-  });
-
   it('Create Price', function() {
     Builder.createBasicPriceEntities(priceSystemName, priceListVersionName, priceListName, false);
 

--- a/cypress/integration/sales/adjustment_charge_price_difference_for_sales_invoice.js
+++ b/cypress/integration/sales/adjustment_charge_price_difference_for_sales_invoice.js
@@ -22,10 +22,9 @@
 
 /// <reference types="Cypress" />
 
-import { getLanguageSpecific } from '../../support/utils/utils';
 import { salesInvoices } from '../../page_objects/sales_invoices';
 import { SalesInvoice, SalesInvoiceLine } from '../../support/utils/sales_invoice';
-import { DocumentActionKey, DocumentStatusKey } from '../../support/utils/constants';
+import { DocumentStatusKey } from '../../support/utils/constants';
 
 describe('Create Adjustment Charge price difference (Nachbelastung Preisdifferenz) for Sales Invoice', function() {
   const adjustmentChargePriceDifference = 'Nachbelastung - Preisdifferenz';
@@ -46,33 +45,11 @@ describe('Create Adjustment Charge price difference (Nachbelastung Preisdifferen
   const productName = 'Convenience Salat 250g';
   const originalQuantity = 200;
 
-  before(function() {
-    // This wait is stupid.
-    // It also appears to be a good workaround for the problems in
-    // cypress/support/utils/utils.js:1
-    cy.wait(5000);
-  });
-
   it('Prepare sales invoice', function() {
-    cy.fixture('sales/sales_invoice.json').then(salesInvoiceJson => {
-      new SalesInvoice(businessPartnerName, salesInvoiceTargetDocumentType)
-        .addLine(
-          new SalesInvoiceLine().setProduct(productName).setQuantity(originalQuantity)
-          // todo @dh: how to add a "per test" packing item
-          // .setPackingItem('IFCO 6410 x 10 Stk')
-          // .setTuQuantity(2)
-        )
-        // .addLine(
-        // todo @dh: how to add this line which depends on the packing item?
-        //   new SalesInvoiceLine()
-        //     .setProduct('IFCO 6410_P001512')
-        //     .setQuantity(2)
-        // )
-        // .setPriceList(priceListName)
-        .setDocumentAction(getLanguageSpecific(salesInvoiceJson, DocumentActionKey.Complete))
-        .setDocumentStatus(getLanguageSpecific(salesInvoiceJson, DocumentStatusKey.Completed))
-        .apply();
-    });
+    new SalesInvoice(businessPartnerName, salesInvoiceTargetDocumentType)
+      .addLine(new SalesInvoiceLine().setProduct(productName).setQuantity(originalQuantity))
+      .apply();
+    cy.completeDocument();
 
     // this is stupid. it seems that with cypress you can ONLY read the alias in the same "it" block. so i cannot retrieve my aliases
     // in an organised (to be read "sane") fashion inside 'Save values needed for the next step', but must do it here, even though
@@ -82,10 +59,6 @@ describe('Create Adjustment Charge price difference (Nachbelastung Preisdifferen
       originalSalesInvoiceID = documentId;
       cy.log(`originalSalesInvoiceID is ${originalSalesInvoiceID}`);
     });
-  });
-
-  it('Sales Invoice is Completed', function() {
-    cy.expectDocumentStatus(DocumentStatusKey.Completed);
   });
 
   it('Sales Invoice is not paid', function() {
@@ -189,13 +162,7 @@ describe('Create Adjustment Charge price difference (Nachbelastung Preisdifferen
   });
 
   it('Complete the Adjustment Charge SI', function() {
-    // complete it and verify the status
-    cy.fixture('misc/misc_dictionary.json').then(miscDictionary => {
-      cy.processDocument(
-        getLanguageSpecific(miscDictionary, DocumentActionKey.Complete),
-        getLanguageSpecific(miscDictionary, DocumentStatusKey.Completed)
-      );
-    });
+    cy.completeDocument();
   });
 
   it('Total amount should be lower than the original SI', function() {

--- a/cypress/integration/sales/adjustment_charge_quantity_difference_for_sales_invoice.js
+++ b/cypress/integration/sales/adjustment_charge_quantity_difference_for_sales_invoice.js
@@ -22,13 +22,11 @@
 
 /// <reference types="Cypress" />
 
-import { getLanguageSpecific } from '../../support/utils/utils';
 import { salesInvoices } from '../../page_objects/sales_invoices';
 import { SalesInvoice, SalesInvoiceLine } from '../../support/utils/sales_invoice';
-import { DocumentActionKey, DocumentStatusKey } from '../../support/utils/constants';
+import { DocumentStatusKey } from '../../support/utils/constants';
 
 describe('Create Adjustment Charge quantity difference (Nachbelastung Mengendifferenz) for Sales Invoice', function() {
-
   const adjustmentChargeQuantityDifference = 'Nachbelastung - Mengendifferenz';
   let originalSalesInvoiceNumber;
   let originalPriceList;
@@ -47,33 +45,11 @@ describe('Create Adjustment Charge quantity difference (Nachbelastung Mengendiff
   const productName = 'Convenience Salat 250g';
   const originalQuantity = 200;
 
-  before(function() {
-    // This wait is stupid.
-    // It also appears to be a good workaround for the problems in
-    // cypress/support/utils/utils.js:1
-    cy.wait(5000);
-  });
-
   it('Prepare sales invoice', function() {
-    cy.fixture('sales/sales_invoice.json').then((salesInvoiceJson) => {
-      new SalesInvoice(businessPartnerName, salesInvoiceTargetDocumentType)
-        .addLine(
-          new SalesInvoiceLine().setProduct(productName).setQuantity(originalQuantity)
-          // todo @dh: how to add a "per test" packing item
-          // .setPackingItem('IFCO 6410 x 10 Stk')
-          // .setTuQuantity(2)
-        )
-        // .addLine(
-        // todo @dh: how to add this line which depends on the packing item?
-        //   new SalesInvoiceLine()
-        //     .setProduct('IFCO 6410_P001512')
-        //     .setQuantity(2)
-        // )
-        // .setPriceList(priceListName)
-        .setDocumentAction(getLanguageSpecific(salesInvoiceJson, DocumentActionKey.Complete))
-        .setDocumentStatus(getLanguageSpecific(salesInvoiceJson, DocumentStatusKey.Completed))
-        .apply();
-    });
+    new SalesInvoice(businessPartnerName, salesInvoiceTargetDocumentType)
+      .addLine(new SalesInvoiceLine().setProduct(productName).setQuantity(originalQuantity))
+      .apply();
+    cy.completeDocument();
 
     // this is stupid. it seems that with cypress you can ONLY read the alias in the same "it" block. so i cannot retrieve my aliases
     // in an organised (to be read "sane") fashion inside 'Save values needed for the next step', but must do it here, even though
@@ -190,13 +166,7 @@ describe('Create Adjustment Charge quantity difference (Nachbelastung Mengendiff
   });
 
   it('Complete the Adjustment Charge SI', function() {
-    // complete it and verify the status
-    cy.fixture('misc/misc_dictionary.json').then(miscDictionary => {
-      cy.processDocument(
-        getLanguageSpecific(miscDictionary, DocumentActionKey.Complete),
-        getLanguageSpecific(miscDictionary, DocumentStatusKey.Completed)
-      );
-    });
+    cy.completeDocument();
   });
 
   it('Total amount should be lower than the original SI', function() {
@@ -207,7 +177,7 @@ describe('Create Adjustment Charge quantity difference (Nachbelastung Mengendiff
     cy.getCheckboxValue('IsPaid').then(checkBoxValue => {
       cy.log(`IsPaid = ${checkBoxValue}`);
       assert.equal(checkBoxValue, false);
-    })
+    });
   });
 
   it('Original Sales Invoice is not paid', function() {
@@ -217,5 +187,4 @@ describe('Create Adjustment Charge quantity difference (Nachbelastung Mengendiff
       assert.equal(checkBoxValue, false);
     });
   });
-
 });

--- a/cypress/integration/sales/credit_memo_deliver_difference_for_sales_invoice.js
+++ b/cypress/integration/sales/credit_memo_deliver_difference_for_sales_invoice.js
@@ -22,13 +22,11 @@
 
 /// <reference types="Cypress" />
 
-import { getLanguageSpecific } from '../../support/utils/utils';
 import { salesInvoices } from '../../page_objects/sales_invoices';
 import { SalesInvoice, SalesInvoiceLine } from '../../support/utils/sales_invoice';
-import { DocumentActionKey, DocumentStatusKey, RewriteURL } from '../../support/utils/constants';
+import { DocumentStatusKey, RewriteURL } from '../../support/utils/constants';
 
 describe('Create a Credit memo deliver difference for Sales Invoice', function() {
-
   const creditMemoDeliverDiff = 'Credit Memo - Deliver Diff';
   let originalSalesInvoiceNumber;
   let originalPriceList;
@@ -43,42 +41,11 @@ describe('Create a Credit memo deliver difference for Sales Invoice', function()
   const salesInvoiceTargetDocumentType = 'Sales Invoice';
   let originalQuantity = 20;
 
-  before(function() {
-    // This wait is stupid.
-    // It also appears to be a good workaround for the problems in
-    // cypress/support/utils/utils.js:1
-    cy.wait(5000);
-  });
-
   it('Prepare sales invoice', function() {
-    cy.fixture('sales/sales_invoice.json').then((salesInvoiceJson) => {
-      new SalesInvoice('Test Lieferant 1', salesInvoiceTargetDocumentType)
-        .addLine(
-          new SalesInvoiceLine().setProduct('Convenience Salat 250g').setQuantity(originalQuantity)
-          // todo @dh: how to add a "per test" packing item
-          // .setPackingItem('IFCO 6410 x 10 Stk')
-          // .setTuQuantity(2)
-        )
-        // .addLine(
-        // todo @dh: how to add this line which depends on the packing item?
-        //   new SalesInvoiceLine()
-        //     .setProduct('IFCO 6410_P001512')
-        //     .setQuantity(2)
-        // )
-        // .setPriceList(priceListName)
-        .setDocumentAction(getLanguageSpecific(salesInvoiceJson, DocumentActionKey.Complete))
-        .setDocumentStatus(getLanguageSpecific(salesInvoiceJson, DocumentStatusKey.Completed))
-        .apply();
-    });
-
-    // this is stupid. it seems that with cypress you can ONLY read the alias in the same "it" block. so i cannot retrieve my aliases
-    // in an organised (to be read "sane") fashion inside 'Save values needed for the next step', but must do it here, even though
-    // this step should only create the SI.
-    // WAT??!!
-    cy.get('@newInvoiceDocumentId').then(function({ documentId /* this is destructuring */ }) {
-      originalSalesInvoiceID = documentId;
-      cy.log(`originalSalesInvoiceID is ${originalSalesInvoiceID}`);
-    });
+    new SalesInvoice('Test Lieferant 1', salesInvoiceTargetDocumentType)
+      .addLine(new SalesInvoiceLine().setProduct('Convenience Salat 250g').setQuantity(originalQuantity))
+      .apply();
+    cy.completeDocument();
   });
 
   it('Sales Invoice is Completed', function() {
@@ -93,6 +60,8 @@ describe('Create a Credit memo deliver difference for Sales Invoice', function()
   });
 
   it('Save values needed for the next step', function() {
+    cy.getCurrentWindowRecordId().then(id => (originalSalesInvoiceID = id));
+
     cy.getStringFieldValue('DocumentNo').then(documentNumber => {
       originalSalesInvoiceNumber = documentNumber;
     });
@@ -181,32 +150,21 @@ describe('Create a Credit memo deliver difference for Sales Invoice', function()
     cy.pressDoneButton(200);
   });
 
-  let newTotalAmount = 0;
-  it('Save the new total amount', function() {
-    cy.get('.header-breadcrumb-sitename').then(function(si) {
-      newTotalAmount = parseFloat(si.html().split(' ')[2]); // the format is "DOC_NO MM/DD/YYYY total"
-    });
-  });
-
   it('Complete the Credit Memo SI', function() {
-    // complete it and verify the status
-    cy.fixture('misc/misc_dictionary.json').then(miscDictionary => {
-      cy.processDocument(
-        getLanguageSpecific(miscDictionary, DocumentActionKey.Complete),
-        getLanguageSpecific(miscDictionary, DocumentStatusKey.Completed)
-      );
-    });
+    cy.completeDocument();
   });
 
   it('Total amount should be lower than the original SI', function() {
-    expect(newTotalAmount).lessThan(originalSalesInvoiceTotalAmount);
+    cy.getSalesInvoiceTotalAmount().then(newTotalAmount => {
+      expect(newTotalAmount).lessThan(originalSalesInvoiceTotalAmount);
+    });
   });
 
   it('Credit Memo SI is paid', function() {
     cy.getCheckboxValue('IsPaid').then(checkBoxValue => {
       cy.log(`IsPaid = ${checkBoxValue}`);
       assert.equal(checkBoxValue, true);
-    })
+    });
   });
 
   it('Original Sales Invoice is not paid', function() {
@@ -216,5 +174,4 @@ describe('Create a Credit memo deliver difference for Sales Invoice', function()
       assert.equal(checkBoxValue, false);
     });
   });
-
 });

--- a/cypress/integration/sales/void_a_sales_invoice_then_invoice_the_billing_candidates_again.js
+++ b/cypress/integration/sales/void_a_sales_invoice_then_invoice_the_billing_candidates_again.js
@@ -44,14 +44,6 @@ describe('Void Sales Invoice and invoice the billing candidates again', function
   let salesOrderRecordId;
   let totalAmountToPay = 0;
 
-  before(function() {
-    // This wait is stupid.
-    // It also appears to be a good workaround for the problems in
-    // cypress/support/utils/utils.js:1
-    cy.wait(5000);
-    cy.readAllNotifications();
-  });
-
   it('Create Sales Order', function() {
     new SalesOrder()
       .setBPartner(businessPartnerName)
@@ -131,6 +123,7 @@ describe('Void Sales Invoice and invoice the billing candidates again', function
     });
 
     it('Execute action "Generate shipments', function() {
+      cy.readAllNotifications();
       cy.executeHeaderActionWithDialog('M_ShipmentSchedule_EnqueueSelection');
       cy.selectInListField('QuantityType', 'Quantity to deliver', true, null, true);
       cy.setCheckBoxValue('IsCompleteShipments', true, true);
@@ -171,6 +164,7 @@ describe('Void Sales Invoice and invoice the billing candidates again', function
 
   describe('Generate Invoice and check it', function() {
     it('Execute action "Generate Invoices"', function() {
+      cy.readAllNotifications();
       cy.executeHeaderActionWithDialog('C_Invoice_Candidate_EnqueueSelectionForInvoicing');
       cy.pressStartButton(500);
 
@@ -286,6 +280,7 @@ describe('Void Sales Invoice and invoice the billing candidates again', function
     });
 
     it('Execute action "Generate Invoices" the second time', function() {
+      cy.readAllNotifications();
       cy.executeHeaderActionWithDialog('C_Invoice_Candidate_EnqueueSelectionForInvoicing');
       cy.pressStartButton();
 

--- a/cypress/integration/tax/taxrate_setup_spec.js
+++ b/cypress/integration/tax/taxrate_setup_spec.js
@@ -3,8 +3,6 @@ import { getLanguageSpecific, humanReadableNow } from '../../support/utils/utils
 
 describe('Create Taxrate for Automatic End2End Tests with cypress https://github.com/metasfresh/metasfresh-e2e/issues/74', function() {
   it('Create new Taxrate', function() {
-    cy.wait(1000); // see comment/doc of getLanguageSpecific
-
     const date = humanReadableNow();
     const taxrateName = `Text-Tax 10% ${date}`;
 

--- a/cypress/support/commands/navigation.js
+++ b/cypress/support/commands/navigation.js
@@ -51,6 +51,7 @@ Cypress.Commands.add('selectSingleTabRow', () => {
 Cypress.Commands.add('openReferencedDocuments', (referenceId, retriesLeft = 8) => {
   // retry 8 times to open the referenced document
   const date = humanReadableNow();
+  const timeout = { timeout: 20000 };
 
   if (retriesLeft >= 1) {
     const referencesAliasName = `references-${date}`;
@@ -58,9 +59,8 @@ Cypress.Commands.add('openReferencedDocuments', (referenceId, retriesLeft = 8) =
     cy.route('GET', new RegExp(RewriteURL.REFERENCES)).as(referencesAliasName);
 
     cy.get('body').type('{alt}6'); // open referenced docs
-    cy.wait(`@${referencesAliasName}`, { timeout: 20000 });
-
-    cy.get('.order-list-panel .order-list-loader').should('not.exist');
+    cy.wait(`@${referencesAliasName}`, timeout);
+    cy.get('.order-list-panel .order-list-loader', timeout).should('not.exist');
 
     return cy.get('body').then(body => {
       if (body.find(`.reference_${referenceId}`).length > 0) {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -19,6 +19,7 @@ import './commands/navigation';
 import './commands/form';
 import './commands/action';
 import './commands/test';
+import { getLanguageSpecificWorkaround } from './utils/utils';
 
 Cypress.on('uncaught:exception', () => {
   //(err, runnable) => {
@@ -36,7 +37,8 @@ Cypress.on('window:alert', text => {
 });
 
 before(function() {
-  cy.loginViaAPI();
+  // no clue why i have to add this wait, but it seems to be the only way the getLanguageSpecific workaround... works
+  cy.loginViaAPI().wait(100);
 
   Cypress.Cookies.defaults({
     whitelist: ['SESSION', 'isLogged'],

--- a/cypress/support/utils/utils.js
+++ b/cypress/support/utils/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*
  * IMPORTANT: be sure not to do this right at the start of a spec; if in doubt, do an extra "cy.wait(1000)".
  * Otherwise you will likely get this error
@@ -15,32 +16,13 @@
  * 
  */
 const getLanguageSpecific = (data, key) => {
-  // this is more of a guard; it succeeds, even if this whole function fails with; comment it back in, if you are interested, or see a benefit
-  // cy.window()
-  //   .its('store')
-  //   .invoke('getState')
-  //   .its('appHandler.me.language.key')
-  //   .should('exist');
+  const _ = getLanguageSpecificWorkaround();
 
   const lang = Cypress.reduxStore.getState().appHandler.me.language.key;
   if (lang !== 'en_US') {
     key = `${lang}__${key}`;
   }
   return data[key];
-
-  // 1. this gives me
-  //    "CypressError: cy.then() failed because you are mixing up async and sync code.""
-  // 2. if it worked, I still would not know how to wait for all of this to be done asynchronously, and then return my result
-  // cy.wrap(data)
-  //   .should('exist')
-  //   .then(dataObj => {
-  //     cy.log(`dataObj=${JSON.stringify(dataObj)}`);
-  //     if (lang !== 'en_US') {
-  //       key = `${lang}__${key}`;
-  //     }
-  //     return { trl: dataObj[key] };
-  //   })
-  //   .as(`${key}_trl`);
 };
 
 /*
@@ -92,11 +74,31 @@ const humanReadableNow = () => {
 };
 
 let date;
-const appendHumanReadableNow = (str) => {
+const appendHumanReadableNow = str => {
   if (!date) {
     date = humanReadableNow();
   }
   return `${str}_${date}`;
 };
 
-export { getLanguageSpecific, wrapRequest, findByName, humanReadableNow, appendHumanReadableNow };
+const getLanguageSpecificWorkaround_date = new Date();
+const getLanguageSpecificWorkaround = () => {
+  const TIME_TO_WAIT = 6 * 1000;
+  return cy.get('body').then(function() {
+    const now = new Date();
+    const delta = now - getLanguageSpecificWorkaround_date;
+    if (delta < TIME_TO_WAIT) {
+      cy.log(`getLanguageSpecificWorkaround sleeping: date=${getLanguageSpecificWorkaround_date.getTime()}, now=${now.getTime()}, delta=${delta}ms`);
+      return cy.wait(5000);
+    }
+  });
+};
+
+export {
+  getLanguageSpecific,
+  wrapRequest,
+  findByName,
+  humanReadableNow,
+  appendHumanReadableNow,
+  getLanguageSpecificWorkaround,
+};


### PR DESCRIPTION
This should fix the 5 seconds wait in the before section of the tests. We've not gotten rid of the wait, just that it should be done automatically now.