### PR TITLE
Remove document id from cy.visit window

### DIFF
--- a/cypress/fixtures/tax/taxcategory_activate_spec.json
+++ b/cypress/fixtures/tax/taxcategory_activate_spec.json
@@ -1,7 +1,8 @@
 {
-    "taxRateName": "Text-Tax 10%",
-    "validFrom": "01/01/2019",
-    "rate": 10,
+  "taxCategoryName": "Tax Category 10%",
+  "taxRateName": "Text-Tax 10%",
+  "validFrom": "01/01/2019",
+  "rate": 10,
 
   "priceSystemName" : "PriceSystem",
   "priceListName" : "PriceList",
@@ -10,5 +11,4 @@
   "productName" : "Product",
   "standardPrice": 3456,
   "initialTaxCategory" : "Regular Tax Rate 19% (Germany)"
-
 }

--- a/cypress/fixtures/tax/taxrate.json
+++ b/cypress/fixtures/tax/taxrate.json
@@ -1,7 +1,6 @@
 {
   "name": "Test TaxRate",
   "isDefault": false,
-  "taxCategory": "Normaler Steuersatz 19% (Deutschland)",
   "validFrom": "01/01/2019",
   "requiresTaxCertificate": false,
   "rate": 10,

--- a/cypress/fixtures/tax/taxrate_setup_spec.json
+++ b/cypress/fixtures/tax/taxrate_setup_spec.json
@@ -1,7 +1,8 @@
 {
-    "taxRateName": "Text-Tax 10%",
-    "validFrom": "01/01/2019",
-    "rate": 10,
+  "taxRateName": "Text-Tax 10%",
+  "taxCategoryName": "Tax Category 10%",
+  "validFrom": "01/01/2019",
+  "rate": 10,
 
   "priceSystemName" : "PriceSystem",
   "priceListName" : "PriceList",
@@ -9,5 +10,4 @@
 
   "productName" : "Product",
   "standardPrice": 3456
-
 }

--- a/cypress/integration/dataEntry/dataEntry_bpartner_spec.js
+++ b/cypress/integration/dataEntry/dataEntry_bpartner_spec.js
@@ -1,7 +1,7 @@
-import { DataEntryTab, DataEntrySubTab } from '../../support/utils/dataEntryTab';
-import { DataEntrySection, DataEntryLine } from '../../support/utils/dataEntrySection';
+import { DataEntrySubTab, DataEntryTab } from '../../support/utils/dataEntryTab';
+import { DataEntryLine, DataEntrySection } from '../../support/utils/dataEntrySection';
 import { DataEntryField, DataEntryListValue } from '../../support/utils/dataEntryField';
-import { humanReadableNow } from "../../support/utils/utils";
+import { humanReadableNow } from '../../support/utils/utils';
 
 describe('Create bpartner with custom dataentry based tabs', function() {
   const date = humanReadableNow();
@@ -28,19 +28,16 @@ describe('Create bpartner with custom dataentry based tabs', function() {
       )
       .apply();
 
-    cy.get(`@${dataEntryTabName}`).then(newDataEntryTab => {
-      dataEntryTabId = newDataEntryTab.documentId;
-    });
+    cy.getCurrentWindowRecordId().then(id => (dataEntryTabId = id));
     cy.get(`@${dataEntrySubTab1Name}`).then(dataEntrySubTab => {
+      // noinspection JSUnresolvedVariable
       dataEntrySubTab1Id = dataEntrySubTab.documentId;
     });
   });
 
   it('Create dataentry section and lines', function() {
     new DataEntrySection(dataEntrySection1Name, dataEntrySubTab1Name)
-      .setDescription(
-        'Section with 3 lines; in the 1st, just one col is used; in the 2nd, one field is long-text, yet the two fields of the 3rd line shall still be alligned!'
-      )
+      .setDescription('Section with 3 lines; in the 1st, just one col is used; in the 2nd, one field is long-text, yet the two fields of the 3rd line shall still be alligned!')
       .setSeqNo('15')
       .addDataEntryLine(new DataEntryLine().setSeqNo(11))
       .addDataEntryLine(new DataEntryLine().setSeqNo(22))
@@ -49,10 +46,7 @@ describe('Create bpartner with custom dataentry based tabs', function() {
   });
 
   it('Create dataentry fields', function() {
-    const section1FieldBuilder = new DataEntryField(
-      'Tab1-Section1-Line1-Field1',
-      `${dataEntrySection1Name}_${dataEntryTabName}_${dataEntrySubTab1Name}_11`
-    )
+    const section1FieldBuilder = new DataEntryField('Tab1-Section1-Line1-Field1', `${dataEntrySection1Name}_${dataEntryTabName}_${dataEntrySubTab1Name}_11`)
       .setDescription('Yes-No, single field in its line')
       .setMandatory(true)
       .setDataEntryRecordType('Yes-No')
@@ -95,30 +89,20 @@ describe('Create bpartner with custom dataentry based tabs', function() {
       .addDataEntryLine(new DataEntryLine().setSeqNo('10'))
       .apply();
 
-    new DataEntryField(
-      'Tab1-Section2-Line1-Field1',
-      `${dataEntrySection2Name}_${dataEntryTabName}_${dataEntrySubTab1Name}_10`
-    )
+    new DataEntryField('Tab1-Section2-Line1-Field1', `${dataEntrySection2Name}_${dataEntryTabName}_${dataEntrySubTab1Name}_10`)
       .setDescription('Tab1-Section2-Field1 Description')
       .setMandatory(true)
       .setDataEntryRecordType('Date')
       .setSeqNo('10')
       .apply();
 
-    new DataEntryField(
-      'Tab1-Section2-Line1-Field2',
-      `${dataEntrySection2Name}_${dataEntryTabName}_${dataEntrySubTab1Name}_10`
-    )
+    new DataEntryField('Tab1-Section2-Line1-Field2', `${dataEntrySection2Name}_${dataEntryTabName}_${dataEntrySubTab1Name}_10`)
       .setDescription('Tab1-Section2-Field2 Description')
       .setMandatory(false) // setting only the section's 1st field to be mandatory because right now, only the first field is actually displayed
       .setDataEntryRecordType('List')
       .setSeqNo('22')
-      .addDataEntryListValue(
-        new DataEntryListValue('ListItem 2').setDescription('ListItem 2 with SeqNo10').setSeqNo('21')
-      )
-      .addDataEntryListValue(
-        new DataEntryListValue('ListItem 1').setDescription('ListItem 1 with SeqNo20').setSeqNo('11')
-      )
+      .addDataEntryListValue(new DataEntryListValue('ListItem 2').setDescription('ListItem 2 with SeqNo10').setSeqNo('21'))
+      .addDataEntryListValue(new DataEntryListValue('ListItem 1').setDescription('ListItem 1 with SeqNo20').setSeqNo('11'))
       .apply();
   });
 

--- a/cypress/integration/masterdata/bpartner_group_spec.js
+++ b/cypress/integration/masterdata/bpartner_group_spec.js
@@ -28,9 +28,8 @@ describe('Create new bpartner group', function() {
     cy.writeIntoStringField('Name', groupName, false);
     cy.clearField('Value');
     cy.writeIntoStringField('Value', groupName, false);
-    cy.get('@newGroupId').then(groupId => {
-      groupDocumentId = groupId.documentId;
-    });
+
+    cy.getCurrentWindowRecordId().then(id => (groupDocumentId = id));
   });
 
   //create bpartner

--- a/cypress/integration/price/change_product_prices_and_add_a_new_one.js
+++ b/cypress/integration/price/change_product_prices_and_add_a_new_one.js
@@ -55,7 +55,6 @@ let packingInstructionsName1;
 let packingInstructionsName2;
 
 // Product
-let productType;
 let productName1;
 let productName2;
 let productName3;
@@ -92,7 +91,6 @@ it('Read fixture and prepare the names', function() {
     packingInstructionsName1 = appendHumanReadableNow(f['packingInstructionsName1']);
     packingInstructionsName2 = appendHumanReadableNow(f['packingInstructionsName2']);
 
-    productType = f['productType'];
     productName1 = appendHumanReadableNow(f['productName1']);
     productName2 = appendHumanReadableNow(f['productName2']);
     productName3 = appendHumanReadableNow(f['productName3']);
@@ -153,7 +151,6 @@ describe('Create the 3 products ', function() {
     cy.fixture('product/simple_product.json').then(productJson => {
       Object.assign(new Product(), productJson)
         .setName(productName1)
-        .setProductType(productType)
         .setProductCategory(productCategoryName1)
         .addCUTUAllocation(packingInstructionsName1)
         .apply();
@@ -164,7 +161,6 @@ describe('Create the 3 products ', function() {
     cy.fixture('product/simple_product.json').then(productJson => {
       Object.assign(new Product(), productJson)
         .setName(productName2)
-        .setProductType(productType)
         .setProductCategory(productCategoryName1)
         .addCUTUAllocation(packingInstructionsName1)
         .addCUTUAllocation(packingInstructionsName2)
@@ -176,7 +172,6 @@ describe('Create the 3 products ', function() {
     cy.fixture('product/simple_product.json').then(productJson => {
       Object.assign(new Product(), productJson)
         .setName(productName3)
-        .setProductType(productType)
         .setProductCategory(productCategoryName2)
         .addCUTUAllocation(packingInstructionsName1)
         .apply();
@@ -243,7 +238,7 @@ function createProductCategory(productCategoryName, attributeSet) {
 }
 
 function createPackingEntities(productForPacking, packingInstructionsName) {
-  Builder.createProductWithPriceUsingExistingCategory(priceListName, productForPacking, productForPacking, productType, '24_Gebinde');
+  Builder.createProductWithPriceUsingExistingCategory(priceListName, productForPacking, productForPacking, null, '24_Gebinde');
   Builder.createPackingMaterial(productForPacking, packingInstructionsName);
 }
 
@@ -255,6 +250,7 @@ function createProductPriceWithAttributes(productName) {
   cy.get('.form-field-M_AttributeSetInstance_ID').click({ force: true }); // save the attributes
   cy.waitForSaveIndicator(true);
 }
+
 function createProductPrice(productName, priceListName, standardPrice, taxCategory) {
   new ProductPrice()
     .setProduct(productName)
@@ -279,15 +275,18 @@ function editProductAttributes(productName, productID) {
   cy.get('.form-field-M_AttributeSetInstance_ID').click({ force: true }); // save the attributes
   cy.waitForSaveIndicator(true);
 }
+
 function expectNumberOfProductPrices(expectedNumberOfRows, priceListVersionName) {
   ProductPrices.visit();
   toggleNotFrequentFilters();
   selectNotFrequentFilterWidget('default');
-  cy.writeIntoLookupListField('M_PriceList_Version_ID', priceListVersionName, priceListVersionName, false, false, null, true);
+  cy.selectInListField('M_PriceList_Version_ID', priceListVersionName, false, null, true);
+
   cy.setCheckBoxValue('IsAttributeDependant', true, false, null, true);
   applyFilters();
   cy.expectNumberOfRows(expectedNumberOfRows);
 }
+
 function createAttribute(attributeName, attributeValue1, attributeValue2) {
   new Attribute(attributeName)
     .setValue(attributeName)

--- a/cypress/integration/sales/adjustment_charge_price_difference_for_sales_invoice.js
+++ b/cypress/integration/sales/adjustment_charge_price_difference_for_sales_invoice.js
@@ -55,19 +55,13 @@ describe('Create Adjustment Charge price difference (Nachbelastung Preisdifferen
   });
 
   it('Prepare sales invoice', function() {
+    // eslint-disable-next-line
     new SalesInvoice(businessPartnerName, salesInvoiceTargetDocumentType)
       .addLine(new SalesInvoiceLine().setProduct(productName).setQuantity(originalQuantity))
       .apply();
     cy.completeDocument();
 
-    // this is stupid. it seems that with cypress you can ONLY read the alias in the same "it" block. so i cannot retrieve my aliases
-    // in an organised (to be read "sane") fashion inside 'Save values needed for the next step', but must do it here, even though
-    // this step should only create the SI.
-    // WAT??!!
-    cy.get('@newInvoiceDocumentId').then(function({ documentId /* this is destructuring */ }) {
-      originalSalesInvoiceID = documentId;
-      cy.log(`originalSalesInvoiceID is ${originalSalesInvoiceID}`);
-    });
+    cy.getCurrentWindowRecordId().then(id => (originalSalesInvoiceID = id));
   });
 
   it('Sales Invoice is not paid', function() {

--- a/cypress/integration/sales/adjustment_charge_quantity_difference_for_sales_invoice.js
+++ b/cypress/integration/sales/adjustment_charge_quantity_difference_for_sales_invoice.js
@@ -57,19 +57,13 @@ describe('Create Adjustment Charge quantity difference (Nachbelastung Mengendiff
   });
 
   it('Prepare sales invoice', function() {
+    // eslint-disable-next-line
     new SalesInvoice(businessPartnerName, salesInvoiceTargetDocumentType)
       .addLine(new SalesInvoiceLine().setProduct(productName).setQuantity(originalQuantity))
       .apply();
     cy.completeDocument();
 
-    // this is stupid. it seems that with cypress you can ONLY read the alias in the same "it" block. so i cannot retrieve my aliases
-    // in an organised (to be read "sane") fashion inside 'Save values needed for the next step', but must do it here, even though
-    // this step should only create the SI.
-    // WAT??!!
-    cy.get('@newInvoiceDocumentId').then(function({ documentId /* this is destructuring */ }) {
-      originalSalesInvoiceID = documentId;
-      cy.log(`originalSalesInvoiceID is ${originalSalesInvoiceID}`);
-    });
+    cy.getCurrentWindowRecordId().then(id => (originalSalesInvoiceID = id));
   });
 
   it('Sales Invoice is Completed', function() {

--- a/cypress/integration/tax/taxcategory_activate_spec.js
+++ b/cypress/integration/tax/taxcategory_activate_spec.js
@@ -6,6 +6,7 @@ import { ProductPrice } from '../../support/utils/product_price';
 
 // tax
 let taxRateName;
+let taxCategoryName;
 let validFrom;
 let rate;
 
@@ -25,6 +26,7 @@ describe('Test TaxCategory activation and deactivation', function() {
   it('Read the fixture', function() {
     cy.fixture('tax/taxcategory_activate_spec.json').then(f => {
       taxRateName = appendHumanReadableNow(f['taxRateName']);
+      taxCategoryName = appendHumanReadableNow(f['taxCategoryName']);
       validFrom = f['validFrom'];
       rate = f['rate'];
 
@@ -41,7 +43,7 @@ describe('Test TaxCategory activation and deactivation', function() {
   it('Create TaxCategory', function() {
     cy.fixture('tax/taxcategory.json').then(taxCategoryJson => {
       Object.assign(new TaxCategory(), taxCategoryJson)
-        .setName(taxRateName)
+        .setName(taxCategoryName)
         .apply();
     });
     cy.getCurrentWindowRecordId().then(id => (taxCategoryId = id));
@@ -53,7 +55,7 @@ describe('Test TaxCategory activation and deactivation', function() {
         .setName(taxRateName)
         .setRate(rate)
         .setValidFrom(validFrom)
-        .setTaxCategory(taxRateName)
+        .setTaxCategory(taxCategoryName)
         .apply();
     });
   });
@@ -86,7 +88,7 @@ describe('Test TaxCategory activation and deactivation', function() {
       .click()
       .get('.input-dropdown-list')
       .should($list => {
-        expect($list.text()).to.not.contain(taxRateName);
+        expect($list.text()).to.not.contain(taxCategoryName);
       });
   });
 
@@ -103,7 +105,7 @@ describe('Test TaxCategory activation and deactivation', function() {
       .click()
       .get('.input-dropdown-list')
       .should($list => {
-        expect($list.text()).to.contain(taxRateName);
+        expect($list.text()).to.contain(taxCategoryName);
       });
   });
 });

--- a/cypress/integration/tax/taxrate_setup_spec.js
+++ b/cypress/integration/tax/taxrate_setup_spec.js
@@ -7,6 +7,7 @@ import { Builder } from '../../support/utils/builder';
 describe('Create new TaxRate', function() {
   // tax
   let taxRateName;
+  let taxCategoryName;
   let validFrom;
   let rate;
 
@@ -20,6 +21,7 @@ describe('Create new TaxRate', function() {
   it('Read the fixture', function() {
     cy.fixture('tax/taxrate_setup_spec.json').then(f => {
       taxRateName = appendHumanReadableNow(f['taxRateName']);
+      taxCategoryName = appendHumanReadableNow(f['taxCategoryName']);
       validFrom = f['validFrom'];
       rate = f['rate'];
 
@@ -35,7 +37,7 @@ describe('Create new TaxRate', function() {
   it('Create TaxCategory', function() {
     cy.fixture('tax/taxcategory.json').then(taxCategoryJson => {
       Object.assign(new TaxCategory(), taxCategoryJson)
-        .setName(taxRateName)
+        .setName(taxCategoryName)
         .apply();
     });
   });
@@ -46,7 +48,7 @@ describe('Create new TaxRate', function() {
         .setName(taxRateName)
         .setRate(rate)
         .setValidFrom(validFrom)
-        .setTaxCategory(taxRateName)
+        .setTaxCategory(taxCategoryName)
         .apply();
     });
   });
@@ -62,9 +64,9 @@ describe('Create new TaxRate', function() {
       .setIsAttributeDependant(true)
       .setPriceListVersion(priceListName)
       .setStandardPrice(standardPrice)
-      .setTaxCategory(taxRateName)
+      .setTaxCategory(taxCategoryName)
       .apply();
 
-    cy.getStringFieldValue('C_TaxCategory_ID').should('equals', taxRateName);
+    cy.getStringFieldValue('C_TaxCategory_ID').should('equals', taxCategoryName);
   });
 });

--- a/cypress/integration_defunct/misc/user_spec.js
+++ b/cypress/integration_defunct/misc/user_spec.js
@@ -24,9 +24,9 @@ describe('New user tests', function() {
   it('Create a user', function() {
     user = new User({ ...userJSON, lastName: customLastName, email: customEmail });
     user.apply();
-    cy.get(`@${customEmail}`).then(user => {
-      userId = user.documentId;
-    });
+    // cy.get(`@${customEmail}`).then(user => {
+    //   userId = user.documentId;
+    // })
 
     cy.get('form-field-Login').should('not.exist');
   });

--- a/cypress/page_objects/inventory.js
+++ b/cypress/page_objects/inventory.js
@@ -12,47 +12,48 @@ class Inventory extends Metasfresh {
     this.inventoryLineTabId = 'AD_Tab-256';
   }
 
-  /**
-   * Gets the inventory data and snapshots it, ignoring properties that are not the invariant between different tests.
-   *
-   * @param inventoryRecord the record to snapshot. Its id can by accessed via inventoryRecord.documentId
-   * @param labelPrefix prefix for the snapshot label to use
-   */
-  toMatchSnapshots(inventoryRecord, labelPrefix) {
-    cy.log(`InventoryId=${inventoryRecord.documentId}`);
-    cy.request('GET', `${config.API_URL}/window/${inventory.windowId}/${inventoryRecord.documentId}`).then(response => {
-      expect(response.body, 'inventoryJson - length').to.have.lengthOf(1);
-      const inventoryJson = response.body[0];
-
-      // remove the fields that are different on each test run from the JSON; the result is invariant between test runs
-      inventoryJson.id = 'REPLACED_WITH_CONST';
-      inventoryJson.websocketEndpoint = 'REPLACED_WITH_CONST';
-      inventoryJson.fieldsByName.DocumentNo.value = 'REPLACED_WITH_CONST';
-      inventoryJson.fieldsByName.V$DocumentSummary = 'REPLACED_WITH_CONST';
-      inventoryJson.fieldsByName.ID.value = 'REPLACED_WITH_CONST';
-      inventoryJson.fieldsByName.MovementDate.value = 'REPLACED_WITH_CONST';
-      inventoryJson.fieldsByName.Posted.displayed = 'WE_DONT_CARE_IN_THIS_SPEC';
-      cy.wrap(inventoryJson).toMatchSnapshot(`${labelPrefix}_header`);
-    });
-
-    cy.request(
-      'GET',
-      `${config.API_URL}/window/${inventory.windowId}/${inventoryRecord.documentId}/${inventory.inventoryLineTabId}`
-    ).then(response => {
-      const inventoryLinesJson = response.body;
-
-      inventoryLinesJson.forEach(function(inventoryLineJson) {
-        inventoryLineJson.id = 'REPLACED_WITH_CONST';
-        inventoryLineJson.rowId = 'REPLACED_WITH_CONST';
-        inventoryLineJson.websocketEndpoint = 'REPLACED_WITH_CONST';
-        inventoryLineJson.fieldsByName.ID.value = 'REPLACED_WITH_CONST';
-        inventoryLineJson.fieldsByName.M_HU_ID.value = 'REPLACED_WITH_CONST';
-        inventoryLineJson.fieldsByName.M_Product_ID.value = 'REPLACED_WITH_CONST';
-      });
-
-      cy.wrap(inventoryLinesJson).toMatchSnapshot(`${labelPrefix}_lives`);
-    });
-  }
+  // can this be deleted? if it's past 2019.11 then yes!
+  // /**
+  //  * Gets the inventory data and snapshots it, ignoring properties that are not the invariant between different tests.
+  //  *
+  //  * @param inventoryRecord the record to snapshot. Its id can by accessed via inventoryRecord.documentId
+  //  * @param labelPrefix prefix for the snapshot label to use
+  //  */
+  // toMatchSnapshots(inventoryRecord, labelPrefix) {
+  //   cy.log(`InventoryId=${inventoryRecord.documentId}`);
+  //   cy.request('GET', `${config.API_URL}/window/${inventory.windowId}/${inventoryRecord.documentId}`).then(response => {
+  //     expect(response.body, 'inventoryJson - length').to.have.lengthOf(1);
+  //     const inventoryJson = response.body[0];
+  //
+  //     // remove the fields that are different on each test run from the JSON; the result is invariant between test runs
+  //     inventoryJson.id = 'REPLACED_WITH_CONST';
+  //     inventoryJson.websocketEndpoint = 'REPLACED_WITH_CONST';
+  //     inventoryJson.fieldsByName.DocumentNo.value = 'REPLACED_WITH_CONST';
+  //     inventoryJson.fieldsByName.V$DocumentSummary = 'REPLACED_WITH_CONST';
+  //     inventoryJson.fieldsByName.ID.value = 'REPLACED_WITH_CONST';
+  //     inventoryJson.fieldsByName.MovementDate.value = 'REPLACED_WITH_CONST';
+  //     inventoryJson.fieldsByName.Posted.displayed = 'WE_DONT_CARE_IN_THIS_SPEC';
+  //     cy.wrap(inventoryJson).toMatchSnapshot(`${labelPrefix}_header`);
+  //   });
+  //
+  //   cy.request(
+  //     'GET',
+  //     `${config.API_URL}/window/${inventory.windowId}/${inventoryRecord.documentId}/${inventory.inventoryLineTabId}`
+  //   ).then(response => {
+  //     const inventoryLinesJson = response.body;
+  //
+  //     inventoryLinesJson.forEach(function(inventoryLineJson) {
+  //       inventoryLineJson.id = 'REPLACED_WITH_CONST';
+  //       inventoryLineJson.rowId = 'REPLACED_WITH_CONST';
+  //       inventoryLineJson.websocketEndpoint = 'REPLACED_WITH_CONST';
+  //       inventoryLineJson.fieldsByName.ID.value = 'REPLACED_WITH_CONST';
+  //       inventoryLineJson.fieldsByName.M_HU_ID.value = 'REPLACED_WITH_CONST';
+  //       inventoryLineJson.fieldsByName.M_Product_ID.value = 'REPLACED_WITH_CONST';
+  //     });
+  //
+  //     cy.wrap(inventoryLinesJson).toMatchSnapshot(`${labelPrefix}_lives`);
+  //   });
+  // }
 }
 
 export const inventory = new Inventory();

--- a/cypress/support/commands/form.js
+++ b/cypress/support/commands/form.js
@@ -136,7 +136,7 @@ Cypress.Commands.add('clickOnCheckBox', (fieldName, expectedPatchValue, modal, r
 
   cy.get(path)
     .find('.input-checkbox-tick')
-    .click({ force: true }); // we don't care if the checkbox scrolled out of view
+    .click(); // we don't care if the checkbox scrolled out of view
   if (!skipPatch) {
     cy.waitForFieldValue(`@${patchCheckBoxAliasName}`, fieldName, expectedPatchValue);
   }

--- a/cypress/support/commands/general.js
+++ b/cypress/support/commands/general.js
@@ -209,63 +209,43 @@ function visitTableWindow(windowId) {
   cy.visit(`/window/${windowId}`);
 }
 
-function visitDetailWindow(windowId, recordId, documentIdAliasName) {
+function visitDetailWindow(windowId, recordId) {
   describe('Open metasfresh single-record window and wait for layout and data', function() {
     performDocumentViewAction(
       windowId,
       function() {
         cy.visit(`/window/${windowId}/${recordId}`);
-      },
-      documentIdAliasName
-    );
+      });
   });
 }
 
-Cypress.Commands.add(
-  'performDocumentViewAction',
-  (windowId, documentViewAction, documentIdAliasName = 'visitedDocumentId') => {
-    performDocumentViewAction(windowId, documentViewAction, documentIdAliasName);
-  }
-);
+Cypress.Commands.add('performDocumentViewAction', (windowId, documentViewAction) => {
+  performDocumentViewAction(windowId, documentViewAction);
+});
 
-function performDocumentViewAction(windowId, documentViewAction, documentIdAliasName) {
+function performDocumentViewAction(windowId, documentViewAction) {
   cy.server();
   const layoutAliasName = `visitWindow-layout-${new Date().getTime()}`;
   cy.route('GET', new RegExp(`/rest/api/window/${windowId}/layout`)).as(layoutAliasName);
   const dataAliasName = `visitWindow-data-${new Date().getTime()}`;
   cy.route('GET', new RegExp(`/rest/api/window/${windowId}/[0-9]+$`)).as(dataAliasName);
 
-  cy.log('Inside performDocumentViewAction, just before the 2 waits');
-
   documentViewAction();
   cy.wait(`@${layoutAliasName}`, {
     requestTimeout: 20000,
     responseTimeout: 20000,
-  })
-    .wait(`@${dataAliasName}`, {
-      requestTimeout: 20000,
-      responseTimeout: 20000,
-    })
-    .then(xhr => {
-      cy.log('FULL XHR: ' + JSON.stringify(xhr));
-
-      expect(xhr).to.not.be.empty;
-      expect(xhr.status).to.eq(200);
-      expect(xhr.response).to.not.be.empty;
-      expect(xhr.response.body[0]).to.not.be.empty;
-
-      cy.log('xhr response body: ' + JSON.stringify(xhr.response.body[0]));
-      return cy.wrap({ documentId: xhr.response.body[0].id });
-    })
-    .as(documentIdAliasName);
+  }).wait(`@${dataAliasName}`, {
+    requestTimeout: 20000,
+    responseTimeout: 20000,
+  });
 }
 
-Cypress.Commands.add('visitWindow', (windowId, recordId, documentIdAliasName = 'visitedDocumentId') => {
+Cypress.Commands.add('visitWindow', (windowId, recordId) => {
   if (recordId == null) {
     // null == undefined, thx to https://stackoverflow.com/a/2647888/1012103
     visitTableWindow(windowId);
   } else {
-    visitDetailWindow(windowId, recordId, documentIdAliasName);
+    visitDetailWindow(windowId, recordId);
   }
 });
 

--- a/cypress/support/commands/general.js
+++ b/cypress/support/commands/general.js
@@ -315,6 +315,8 @@ Cypress.Commands.add('openInboxNotificationWithText', text => {
    *  it would be helpful for cypress if each notification would also contain a data- attribute with the target,
    *  so that i know what to wait after when the notification is clicked, or that nothing should happens.
    *
+   *  This is helpful in case i need to move to a particular window, or whatever else i would need to do.
+   *
    * maybe that notification could contain `data-cy="/window/169/1000043"` or `data-cy=null`.
    *
    *

--- a/cypress/support/commands/test.js
+++ b/cypress/support/commands/test.js
@@ -122,25 +122,22 @@ Cypress.Commands.add('pressDoneButton', waitBeforePress => {
 });
 
 Cypress.Commands.add('pressAddNewButton', (includedDocumentIdAliasName = 'newIncludedDocumentId') => {
-  describe("Press table's add-new-record-button", function() {
-    cy.server();
-    // window/<windowId>/<rootDocumentId>/<tabId>/NEW
-    cy.route('PATCH', new RegExp('/rest/api/window/[^/]+/[^/]+/[^/]+/NEW$')).as('patchNewIncludedDocument');
+  cy.server();
+  // route format: /window/<windowId>/<rootDocumentId>/<tabId>/NEW
+  cy.route('PATCH', new RegExp('/rest/api/window/[^/]+/[^/]+/[^/]+/NEW$')).as('patchNewIncludedDocument');
 
-    const addNewText = Cypress.messages.window.addNew.caption;
-    cy.get('.btn')
-      .contains(addNewText)
-      .should('exist')
-      .click()
-      .wait('@patchNewIncludedDocument')
-      .then(xhr => {
-        return { documentId: xhr.response.body[0].rowId };
-      })
-      .as(includedDocumentIdAliasName);
+  const addNewText = Cypress.messages.window.addNew.caption;
+  cy.get('.btn')
+    .contains(addNewText)
+    .should('exist')
+    .click()
+    .wait('@patchNewIncludedDocument')
+    .then(xhr => {
+      return { documentId: xhr.response.body[0].rowId };
+    })
+    .as(includedDocumentIdAliasName);
 
-    cy.get('.panel-modal').should('exist');
-    //cy.get('.modal-content-wrapper').should('exist'); // this might be another good indicator that we are done loading the modal dialog
-  });
+  cy.get('.panel-modal').should('exist');
 });
 
 /**

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -173,19 +173,16 @@ declare namespace Cypress {
      *
      * @param windowId - the metasfresh AD_Window_ID of the window to visit
      * @param recordId - optional - the record ID of the record to open within the window, or NEW if a new record shall be created. If set the detail layout is shown and cypress waits for the layout into fo be send by the API; otherwise, the "table/grid" layout is shown.
-     * @param documentIdAliasName - optional, default: visitedDocumentId - the name of the alias in which the command will store the actual record; example " { documentId: 1000001 }"; usefull if recordId=NEW;
      *
      * @example
      * // create a new business partner document
-     * cy.visitWindow(123, 'NEW', 'myNewDocumentId')
+     * cy.visitWindow(123, 'NEW')
      *
-     * cy.get('@myNewDcumentId').then((newDocument) => {
-     *   cy.log(`going to do things with the document we added just before; newDocument=${JSON.stringify(newDocument)}`)
-     *   cy.log(`documentId=${newDocument.documentId}`)
-     * })
-     *
+     * cy.getCurrentWindowRecordId().then(id => {
+     *   cy.log('Creating Bpartner with id: ' + id);
+     * });
      */
-    visitWindow(windowId: string | number, recordId?: string | number, documentIdAliasName?: string): Chainable<any>
+    visitWindow(windowId: string | number, recordId?: string | number): Chainable<any>;
 
     /**
      * Wait for the response to a particular patch where a particular field value was set

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -37,7 +37,7 @@ Cypress.on('window:alert', text => {
 
 before(function() {
   // no clue why i have to add this wait, but it seems to be the only way the getLanguageSpecific workaround... works
-  cy.loginViaAPI().wait(100);
+  cy.loginViaAPI().wait(300);
 
   Cypress.Cookies.defaults({
     whitelist: ['SESSION', 'isLogged'],

--- a/cypress/support/utils/dataEntryTab.js
+++ b/cypress/support/utils/dataEntryTab.js
@@ -89,9 +89,7 @@ export class DataEntrySubTab {
 }
 
 function applyDataEntryTab(dataEntryTab) {
-  describe(`Create new dataEntryTab ${dataEntryTab.name}`, function() {
-    cy.visitWindow('540571', 'NEW', dataEntryTab.name /*documentIdAliasName*/);
-    cy.log(`applyDataEntryTab - visitWindow yielded ${JSON.stringify(this.dataEntryTabId)}`);
+  cy.visitWindow('540571', 'NEW');
 
     if (dataEntryTab.seqNo) {
       cy.getStringFieldValue('SeqNo').then(currentValue => {

--- a/cypress/support/utils/dataEntryTab.js
+++ b/cypress/support/utils/dataEntryTab.js
@@ -16,11 +16,13 @@ export class DataEntryTab {
     this.tabName = tabName;
     return this;
   }
+
   setSeqNo(seqNo) {
     cy.log(`DataEntryTab - set seqNo = ${seqNo}`);
     this.seqNo = seqNo;
     return this;
   }
+
   setDescription(description) {
     cy.log(`DataEntryTab - set description = ${description}`);
     this.description = description;
@@ -91,40 +93,33 @@ export class DataEntrySubTab {
 function applyDataEntryTab(dataEntryTab) {
   cy.visitWindow('540571', 'NEW');
 
-    if (dataEntryTab.seqNo) {
-      cy.getStringFieldValue('SeqNo').then(currentValue => {
-        if (currentValue !== dataEntryTab.seqNo) {
-          cy.log(`applyDataEntryTab - dataEntryTab.seqNo=${dataEntryTab.seqNo}; currentValue=${currentValue}`);
-          cy.clearField('SeqNo');
-          cy.writeIntoStringField('SeqNo', `${dataEntryTab.seqNo}`);
-        }
-      });
-    }
+  if (dataEntryTab.seqNo) {
+    cy.getStringFieldValue('SeqNo').then(currentValue => {
+      if (currentValue !== dataEntryTab.seqNo) {
+        cy.clearField('SeqNo');
+        cy.writeIntoStringField('SeqNo', `${dataEntryTab.seqNo}`);
+      }
+    });
+  }
 
-    cy.writeIntoStringField('Name', dataEntryTab.name);
-    cy.writeIntoStringField('TabName', dataEntryTab.tabName);
-    cy.writeIntoLookupListField(
-      'DataEntry_TargetWindow_ID',
-      dataEntryTab.targetWindowName,
-      dataEntryTab.targetWindowName
-    );
+  cy.writeIntoStringField('Name', dataEntryTab.name);
+  cy.writeIntoStringField('TabName', dataEntryTab.tabName);
+  cy.writeIntoLookupListField('DataEntry_TargetWindow_ID', dataEntryTab.targetWindowName, dataEntryTab.targetWindowName);
 
-    if (dataEntryTab.description) {
-      cy.writeIntoTextField('Description', dataEntryTab.description);
-    }
-    if (!dataEntryTab.isActive) {
-      cy.clickOnIsActive(true /*modal*/);
-    }
+  if (dataEntryTab.description) {
+    cy.writeIntoTextField('Description', dataEntryTab.description);
+  }
+  if (!dataEntryTab.isActive) {
+    cy.clickOnIsActive(true /*modal*/);
+  }
 
-    // Thx to https://stackoverflow.com/questions/16626735/how-to-loop-through-an-array-containing-objects-and-access-their-properties
-    if (dataEntryTab.dataEntrySubTabs.length > 0) {
-      dataEntryTab.dataEntrySubTabs.forEach(function(dataEntrySubTab) {
-        applyDataEntrySubTab(dataEntrySubTab);
-      });
-
-      cy.get('table tbody tr').should('have.length', dataEntryTab.dataEntrySubTabs.length);
-    }
-  });
+  // Thx to https://stackoverflow.com/questions/16626735/how-to-loop-through-an-array-containing-objects-and-access-their-properties
+  if (dataEntryTab.dataEntrySubTabs.length > 0) {
+    dataEntryTab.dataEntrySubTabs.forEach(function(dataEntrySubTab) {
+      applyDataEntrySubTab(dataEntrySubTab);
+    });
+    cy.expectNumberOfRows(dataEntryTab.dataEntrySubTabs.length);
+  }
 }
 
 function applyDataEntrySubTab(dataEntrySubTab) {

--- a/cypress/support/utils/product.js
+++ b/cypress/support/utils/product.js
@@ -95,6 +95,8 @@ export class Product {
     cy.log(`Create new Product ${product.name}`);
     cy.visitWindow('140', 'NEW');
 
+    cy.writeIntoStringField('Name', product.name);
+
     cy.setCheckBoxValue('IsStocked', product.isStocked);
     cy.setCheckBoxValue('IsPurchased', product.isPurchased);
     cy.setCheckBoxValue('IsSold', product.isSold);
@@ -108,8 +110,6 @@ export class Product {
         cy.selectInListField('ProductType', productType);
       }
     });
-
-    cy.writeIntoStringField('Name', product.name);
 
     cy.selectInListField('M_Product_Category_ID', product.productCategory);
 

--- a/cypress/support/utils/purchase_invoice.js
+++ b/cypress/support/utils/purchase_invoice.js
@@ -26,28 +26,26 @@ export class PurchaseInvoice {
   }
 
   static applyPurchaseInvoice(purchaseInvoice) {
-    describe(`Create new PurchaseInvoice: ${purchaseInvoice._toString}`, () => {
-      cy.visitWindow('183', 'NEW', 'newInvoiceDocumentId' /*documentIdAliasName*/);
+    cy.visitWindow('183', 'NEW');
 
-      cy.get('.header-breadcrumb-sitename')
-        .should('contain', new Date().getDate())
-        .should('contain', new Date().getFullYear());
+    cy.get('.header-breadcrumb-sitename')
+      .should('contain', new Date().getDate())
+      .should('contain', new Date().getFullYear());
 
-      cy.writeIntoLookupListField('C_BPartner_ID', purchaseInvoice.businessPartner, purchaseInvoice.businessPartner);
+    cy.writeIntoLookupListField('C_BPartner_ID', purchaseInvoice.businessPartner, purchaseInvoice.businessPartner);
 
-      cy.getStringFieldValue('M_PriceList_ID').should('not.be.empty');
-      cy.getStringFieldValue('C_Currency_ID').should('not.be.empty');
-      if (purchaseInvoice.priceList) {
-        cy.selectInListField('M_PriceList_ID', purchaseInvoice.priceList);
-      }
+    cy.getStringFieldValue('M_PriceList_ID').should('not.be.empty');
+    cy.getStringFieldValue('C_Currency_ID').should('not.be.empty');
+    if (purchaseInvoice.priceList) {
+      cy.selectInListField('M_PriceList_ID', purchaseInvoice.priceList);
+    }
 
-      cy.getStringFieldValue('DocumentNo').should('be.empty');
-      cy.selectInListField('C_DocTypeTarget_ID', purchaseInvoice.targetDocumentType);
-      cy.getStringFieldValue('DocumentNo').should('not.be.empty');
+    cy.getStringFieldValue('DocumentNo').should('be.empty');
+    cy.selectInListField('C_DocTypeTarget_ID', purchaseInvoice.targetDocumentType);
+    cy.getStringFieldValue('DocumentNo').should('not.be.empty');
 
-      purchaseInvoice.lines.forEach(line => {
-        PurchaseInvoice.applyLine(line);
-      });
+    purchaseInvoice.lines.forEach(line => {
+      PurchaseInvoice.applyLine(line);
     });
   }
 

--- a/cypress/support/utils/purchase_invoice.js
+++ b/cypress/support/utils/purchase_invoice.js
@@ -18,7 +18,6 @@ export class PurchaseInvoice {
     return this;
   }
 
-  /** Creates a new invoice and stores its documentId as alias newInvoiceDocumentId. */
   apply() {
     cy.log(`PurchaseInvoice - apply START (${this._toString})`);
     PurchaseInvoice.applyPurchaseInvoice(this);

--- a/cypress/support/utils/sales_invoice.js
+++ b/cypress/support/utils/sales_invoice.js
@@ -18,7 +18,6 @@ export class SalesInvoice {
     return this;
   }
 
-  /** Creates a new invoice and stores its documentId as alias newInvoiceDocumentId. */
   apply() {
     cy.log(`SalesInvoice - apply START (${this._toString})`);
     SalesInvoice.applySalesInvoice(this);

--- a/cypress/support/utils/sales_invoice.js
+++ b/cypress/support/utils/sales_invoice.js
@@ -26,28 +26,26 @@ export class SalesInvoice {
   }
 
   static applySalesInvoice(salesInvoice) {
-    describe(`Create new SalesInvoice: ${salesInvoice._toString}`, () => {
-      cy.visitWindow('167', 'NEW', 'newInvoiceDocumentId' /*documentIdAliasName*/);
+    cy.visitWindow('167', 'NEW');
 
-      cy.get('.header-breadcrumb-sitename')
-        .should('contain', new Date().getDate())
-        .should('contain', new Date().getFullYear());
+    cy.get('.header-breadcrumb-sitename')
+      .should('contain', new Date().getDate())
+      .should('contain', new Date().getFullYear());
 
-      cy.writeIntoLookupListField('C_BPartner_ID', salesInvoice.businessPartner, salesInvoice.businessPartner);
+    cy.writeIntoLookupListField('C_BPartner_ID', salesInvoice.businessPartner, salesInvoice.businessPartner);
 
-      cy.getStringFieldValue('M_PriceList_ID').should('not.be.empty');
-      cy.getStringFieldValue('C_Currency_ID').should('not.be.empty');
-      if (salesInvoice.priceList) {
-        cy.selectInListField('M_PriceList_ID', salesInvoice.priceList);
-      }
+    cy.getStringFieldValue('M_PriceList_ID').should('not.be.empty');
+    cy.getStringFieldValue('C_Currency_ID').should('not.be.empty');
+    if (salesInvoice.priceList) {
+      cy.selectInListField('M_PriceList_ID', salesInvoice.priceList);
+    }
 
-      cy.getStringFieldValue('DocumentNo').should('be.empty');
-      cy.selectInListField('C_DocTypeTarget_ID', salesInvoice.targetDocumentType);
-      cy.getStringFieldValue('DocumentNo').should('not.be.empty');
+    cy.getStringFieldValue('DocumentNo').should('be.empty');
+    cy.selectInListField('C_DocTypeTarget_ID', salesInvoice.targetDocumentType);
+    cy.getStringFieldValue('DocumentNo').should('not.be.empty');
 
-      salesInvoice.lines.forEach(line => {
-        SalesInvoice.applyLine(line);
-      });
+    salesInvoice.lines.forEach(line => {
+      SalesInvoice.applyLine(line);
     });
   }
 

--- a/cypress/support/utils/user.js
+++ b/cypress/support/utils/user.js
@@ -54,7 +54,7 @@ export class User {
 
 function applyUser(user) {
   describe(`Create new user ${user.name}`, function() {
-    cy.visitWindow('108', 'NEW', user.email /*documentIdAliasName*/);
+    cy.visitWindow('108', 'NEW');
     cy.writeIntoStringField('Firstname', user.firstName);
     cy.writeIntoStringField('Lastname', user.lastName);
     cy.writeIntoStringField('EMail', user.email);


### PR DESCRIPTION
No longer retrieve `documentId` from `xhr.response.body`. This is done to avoid a possible cypress bug which selects the cancelled network request instead of the ok one (from 2 network requests).

Ref: https://github.com/cypress-io/cypress/issues/4934

https://github.com/metasfresh/metasfresh-e2e/issues/366