### PR TITLE
Language fix for: create_GL_journal_line_entry_spec

### DIFF
--- a/cypress/fixtures/finance/create_GL_journal_line_entry_spec.json
+++ b/cypress/fixtures/finance/create_GL_journal_line_entry_spec.json
@@ -2,6 +2,8 @@
     "description" : "Spende",
     "category" : "Standard",
     "postingType" : "Actual",
+    "de_DE__postingType": "Ist",
+    "de_CH__postingType": "Ist",
     "currency" : "CHF",
     "docType" : "Journal",
     "account" : "1020_UBS Kontokorrent",

--- a/cypress/integration/finance/create_GL_journal_line_entry_spec.js
+++ b/cypress/integration/finance/create_GL_journal_line_entry_spec.js
@@ -1,3 +1,5 @@
+import { getLanguageSpecific } from '../../support/utils/utils';
+
 let description;
 let category;
 let postingType;
@@ -11,7 +13,7 @@ it('Read fixture and prepare the names', function() {
   cy.fixture('finance/create_GL_journal_line_entry_spec.json').then(f => {
     description = f['description'];
     category = f['category'];
-    postingType = f['postingType'];
+    postingType = getLanguageSpecific(f,'postingType');
     currency = f['currency'];
     docType = f['docType'];
     account = f['account'];


### PR DESCRIPTION
Passes locally for EN, and DE (both DE and CH).
Jenkins runs:
de: https://jenkins.metasfresh.com/job/ops/job/run_e2e_tests/793/console
en: https://jenkins.metasfresh.com/job/ops/job/run_e2e_tests/794/console

issue: https://github.com/metasfresh/metasfresh-e2e/issues/361
          and: https://github.com/metasfresh/metasfresh-e2e/issues/123 (the test)